### PR TITLE
chore: bring Alamofire up to 5.6.2

### DIFF
--- a/Plastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Plastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire",
-        "state": {
-          "branch": null,
-          "revision": "f96b619bcb2383b43d898402283924b80e2c4bae",
-          "version": "5.4.3"
-        }
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }


### PR DESCRIPTION
and update to version 2 of Swift Package Manager package declaration

Signed-off-by: Charles Pickering <me@charlespick.xyz>
