### PR TITLE
printer selection and editing

### DIFF
--- a/Plastic.xcodeproj/project.pbxproj
+++ b/Plastic.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4E0EBFD92679166E002BE169 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 4E0EBFD82679166E002BE169 /* Alamofire */; };
 		4E26944B28A16CE700BBC0AB /* Printer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E26944A28A16CE700BBC0AB /* Printer.swift */; };
 		4E26944D28A1719500BBC0AB /* PrintersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E26944C28A1719500BBC0AB /* PrintersView.swift */; };
+		4E26945128A17CBE00BBC0AB /* PrinterEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E26945028A17CBE00BBC0AB /* PrinterEditView.swift */; };
 		4ED2F3E826795013002C0852 /* PrinterScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2F3E726795013002C0852 /* PrinterScreenView.swift */; };
 		4ED2F3EB267950D0002C0852 /* SystemScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2F3EA267950D0002C0852 /* SystemScreenView.swift */; };
 		4ED2F3EE2679510A002C0852 /* ConsoleScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2F3ED2679510A002C0852 /* ConsoleScreenView.swift */; };
@@ -33,6 +34,7 @@
 		4E0EBFA1267874DA002BE169 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4E26944A28A16CE700BBC0AB /* Printer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Printer.swift; sourceTree = "<group>"; };
 		4E26944C28A1719500BBC0AB /* PrintersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintersView.swift; sourceTree = "<group>"; };
+		4E26945028A17CBE00BBC0AB /* PrinterEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterEditView.swift; sourceTree = "<group>"; };
 		4E80961028A0E5A30040288B /* developing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = developing.md; path = docs/developing.md; sourceTree = "<group>"; };
 		4E80961128A0E5A30040288B /* developer-certificate-of-origin */ = {isa = PBXFileReference; lastKnownFileType = text; name = "developer-certificate-of-origin"; path = "docs/developer-certificate-of-origin"; sourceTree = "<group>"; };
 		4E80961228A0E5A30040288B /* code_of_conduct.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = code_of_conduct.md; path = docs/code_of_conduct.md; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 			children = (
 				4E0EBF78267874D9002BE169 /* PlasticApp.swift */,
 				4E26944C28A1719500BBC0AB /* PrintersView.swift */,
+				4E26945028A17CBE00BBC0AB /* PrinterEditView.swift */,
 				4E26944928A16CD300BBC0AB /* moonraker */,
 				4ED2F3F326795142002C0852 /* JobsScreenView.swift */,
 				4ED2F3ED2679510A002C0852 /* ConsoleScreenView.swift */,
@@ -232,6 +235,7 @@
 				4E26944B28A16CE700BBC0AB /* Printer.swift in Sources */,
 				4E0EBFA8267874DA002BE169 /* Persistence.swift in Sources */,
 				4E0EBFA2267874DA002BE169 /* Plastic.xcdatamodeld in Sources */,
+				4E26945128A17CBE00BBC0AB /* PrinterEditView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/PlasticApp.swift
+++ b/src/PlasticApp.swift
@@ -12,11 +12,12 @@ import SwiftUI
 struct PlasticApp: App {
     let persistenceController = PersistenceController.shared
     @State private var printers = Printer.sampleData
+    @State private var selectedPrinter = Printer.sampleData[1].id
 
     var body: some Scene {
         WindowGroup {
             NavigationView {
-                PrintersView(printers: $printers)
+                PrintersView(printers: $printers, selectedPrinter: $selectedPrinter)
             }
         }
     }

--- a/src/PrinterEditView.swift
+++ b/src/PrinterEditView.swift
@@ -1,0 +1,30 @@
+//
+//  PrinterEditView.swift
+//  Plastic
+//
+//  Created by Charles Pickering on 8/8/22.
+//
+
+import SwiftUI
+
+struct PrinterEditView: View {
+    @Binding var data: Printer.ModifiedData
+    @State private var urlString: String = ""
+    
+    var body: some View {
+        Form {
+            Section(header: Text("Printer Information"), footer: Text("iOS does not support Bonjour. You cannot use hostname.local here.")) {
+                TextField("Name", text: $data.name)
+                TextField("IP Address or DNS Name", text: $urlString)
+            }
+        }.onAppear {
+            urlString = data.url
+        }
+    }
+}
+
+struct PrinterEditView_Previews: PreviewProvider {
+    static var previews: some View {
+        PrinterEditView(data: .constant(Printer.sampleData[0].modifiedData))
+    }
+}

--- a/src/PrintersView.swift
+++ b/src/PrintersView.swift
@@ -9,30 +9,65 @@ import SwiftUI
 
 struct PrintersView: View {
     @Binding var printers: [Printer]
+    @Binding var selectedPrinter: UUID
+    @State private var isPresentingEditSheet = false
+    @State private var newPrinterData = Printer.ModifiedData()
     
     var body: some View {
         List{
             ForEach(printers) { printer in
-                PrinterCardView(printer: printer)
+                PrinterCardView(printer: printer, selected: (selectedPrinter == printer.id))
             }
         }
         .navigationTitle("Printers")
+        .toolbar() {
+            Button(action: { isPresentingEditSheet = true }) { Image(systemName: "plus") }
+        }
+        .sheet(isPresented: $isPresentingEditSheet) {
+            NavigationView {
+                PrinterEditView(data: $newPrinterData)
+                    .toolbar() {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") {
+                                isPresentingEditSheet = false
+                                newPrinterData = Printer.ModifiedData()
+                            }
+                        }
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") {
+                                isPresentingEditSheet = false
+                                let newPrinter = Printer(data: newPrinterData)
+                                printers.append(newPrinter)
+                                newPrinterData = Printer.ModifiedData()
+                            }
+                        }
+                }
+                    .navigationTitle("Add Printer")
+            }
+        }
     }
 }
 
 struct PrintersView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            PrintersView(printers: .constant(Printer.sampleData))
+            PrintersView(printers: .constant(Printer.sampleData), selectedPrinter: .constant(Printer.sampleData[0].id))
         }
     }
 }
 
 struct PrinterCardView: View {
     let printer: Printer
+    let selected: Bool
     
     var body: some View {
-        VStack{
+        HStack{
+            if (selected) {
+                Image(systemName: "checkmark.circle.fill")
+            } else {
+                Image(systemName: "circle")
+            }
+            
             Text(printer.name)
         }
     }

--- a/src/moonraker/Printer.swift
+++ b/src/moonraker/Printer.swift
@@ -10,18 +10,39 @@ import Foundation
 struct Printer: Identifiable, Codable {
     let id: UUID
     var name: String
-    var url: URL
+    var url: String
     
-    init(id: UUID = UUID(), name: String, url: URL) {
+    init(id: UUID = UUID(), name: String, url: String) {
         self.id = id
         self.name = name
         self.url = url
+    }
+    
+    // These items support modifying and adding printers at runtime
+    struct ModifiedData {
+        var name: String = ""
+        var url: String = ""
+    }
+    
+    var modifiedData: ModifiedData {
+        ModifiedData(name: name, url: url)
+    }
+    
+    mutating func update(from data: ModifiedData) {
+        name = data.name
+        url = data.url
+    }
+    
+    init(data: ModifiedData) {
+        id = UUID()
+        name = data.name
+        url = data.url
     }
 }
 
 extension Printer {
     static let sampleData: [Printer] = [
-        Printer(name: "Voron", url: URL(string: "voron.makerland.xyz")!),
-        Printer(name: "CR10", url: URL(string: "192.168.200.5")!)
+        Printer(name: "Voron", url: "voron.makerland.xyz"),
+        Printer(name: "CR10", url: "192.168.200.5")
     ]
 }


### PR DESCRIPTION
next up - persistent storage

When I setup persistent storage, I will address first time startup triggering adding 1 printer, moving sampledata to the coredata stack, and proper selecting a printer and evaluating it down the chain of views. 

Signed-off-by: Charles Pickering <me@charlespick.xyz>