### PR TITLE
feat: selection persists between restarts of the app

### DIFF
--- a/src/PlasticApp.swift
+++ b/src/PlasticApp.swift
@@ -11,6 +11,7 @@ import CoreData
 @main
 struct PlasticApp: App {
     @StateObject private var store = PrinterConfigStore()
+    @State private var selectedPrinterIndex: Int = -1
     
     var body: some Scene {
         WindowGroup {
@@ -18,6 +19,17 @@ struct PlasticApp: App {
                 PrintersView(printers: $store.configuredPrinters) {
                     PrinterConfigStore.save(printerConfigs: store.configuredPrinters) { result in
                         if case .failure(let error) = result { fatalError(error.localizedDescription) }
+                    }
+                } selectAction: { uuid in
+                    if (selectedPrinterIndex != -1) {
+                        store.configuredPrinters[selectedPrinterIndex].renderSelected = false
+                    }
+                    for (index, printer) in store.configuredPrinters.enumerated() {
+                        if (printer.id == uuid) {
+                            store.configuredPrinters[index].renderSelected = true
+                            selectedPrinterIndex = index
+                            return
+                        }
                     }
                 }
             }
@@ -29,6 +41,11 @@ struct PlasticApp: App {
                     case .success(let printers):
                         // The storage layer is holding the configured printers and processing the data but not transfering it internally for now. I will consider condencing this at a later time.
                         store.configuredPrinters = printers
+                    }
+                    for (index, printer) in store.configuredPrinters.enumerated() {
+                        if (printer.renderSelected == true) {
+                            selectedPrinterIndex = index
+                        }
                     }
                 }
             }

--- a/src/PrintersView.swift
+++ b/src/PrintersView.swift
@@ -14,11 +14,14 @@ struct PrintersView: View {
     @State private var newPrinterData = PrinterConfig.ModifiedData()
     @Environment(\.scenePhase) private var scenePhase
     let saveCall: ()->Void
+    let selectAction: (_ printerID: UUID)->Void
     
     var body: some View {
         List{
             ForEach(printers) { printer in
-                PrinterCardView(printer: printer)
+                PrinterCardView(printer: printer, selectAction: { printerID in
+                    selectAction(printerID)
+                })
             }
         }
         .navigationTitle("Printers")
@@ -56,22 +59,26 @@ struct PrintersView: View {
 struct PrintersView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            PrintersView(printers: .constant(PrinterConfig.sampleData), saveCall: {})
+            PrintersView(printers: .constant(PrinterConfig.sampleData), saveCall: {}, selectAction: { printerID in })
         }
     }
 }
 
 struct PrinterCardView: View {
     let printer: PrinterConfig
+    let selectAction: (_ printerID: UUID)->Void
+    
     var body: some View {
-        HStack{
-            if (printer.renderSelected) {
-                Image(systemName: "checkmark.circle.fill")
-            } else {
-                Image(systemName: "circle")
+        Button( action: {selectAction(printer.id)} ) {
+            HStack{
+                if (printer.renderSelected) {
+                    Image(systemName: "checkmark.circle.fill")
+                } else {
+                    Image(systemName: "circle")
+                }
+                
+                Text(printer.name)
             }
-            
-            Text(printer.name)
         }
     }
 }


### PR DESCRIPTION
and printers are also selectable now. the selectedPrinterIndex always keeps track of
the selected printer and is a pointer to only 1 printer in the array of configured printers.
next up: a printer struct will live in the app's kernel to hold the printer's data and coordinate
connections. when the selected printer changes, this object will be destroyed and recreated

Signed-off-by: Charles Pickering <me@charlespick.xyz>