### PR TITLE
fix: team and package identifier remain consistent

### DIFF
--- a/Plastic.xcodeproj/project.pbxproj
+++ b/Plastic.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = dev;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = RJF7UPKG3M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -339,7 +339,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = dev;
-				PRODUCT_BUNDLE_IDENTIFIER = com.charlespick.Plastic;
+				PRODUCT_BUNDLE_IDENTIFIER = com.charlespick.plastic;
 				PRODUCT_NAME = Plastic;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -354,7 +354,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = dev;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = RJF7UPKG3M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = dev;
-				PRODUCT_BUNDLE_IDENTIFIER = com.charlespick.Plastic;
+				PRODUCT_BUNDLE_IDENTIFIER = com.charlespick.plastic;
 				PRODUCT_NAME = Plastic;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
I'm now a developer program member and was able to delete the old identifiers that were blocking com.charlespick.plastic from being used. You may still need to change the package and definitely add your own team to compile for testing. 

Signed-off-by: Charles Pickering <me@charlespick.xyz>